### PR TITLE
Update net.markdown

### DIFF
--- a/doc/api/net.markdown
+++ b/doc/api/net.markdown
@@ -348,7 +348,7 @@ Construct a new socket object.
 
 `options` is an object with the following defaults:
 
-    { fd: null
+    { fd: null,
       allowHalfOpen: false,
       readable: false,
       writable: false


### PR DESCRIPTION
net: Update documentation. Missing "," in options params
